### PR TITLE
Add support for file glob patterns and draft releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ You must provide:
 - `tag`: The tag to uploaded into. If you want the current event's tag, use `${{ github.ref }}`
 - `overwrite`: If an asset with the same name already exists, overwrite it.
 
+
+Optional Arguments
+
+ - `draft`: The release will be marked as a draft if this is set
+ - `file_glob`: If set to true, the file argument can be a glob pattern (asset_name is ignored in this case)
 ## Usage
 
 This usage assumes you want to build on tag creations only.
@@ -91,4 +96,37 @@ jobs:
         file: target/release/${{ matrix.artifact_name }}
         asset_name: ${{ matrix.asset_name }}
         tag: ${{ github.ref }}
+```
+
+Example with file_glob and draft
+
+```yaml
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Publish binaries
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: hecrj/setup-rust-action@v1-release
+      with:
+        rust-version: stable
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --release
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/my*
+        tag: ${{ github.ref }}
+        overwrite: true
+        draft: true
+        file_glob: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,8 @@ inputs:
     required: true
   overwrite:
     description: 'Overwrite the release in case it already exists'
+  file_glob:
+    description: 'if true the file can be a glob pattern, asset_name is ignored if this is true'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,9 @@ inputs:
   overwrite:
     description: 'Overwrite the release in case it already exists'
   file_glob:
-    description: 'if true the file can be a glob pattern, asset_name is ignored if this is true'
+    description: 'if true, the file can be a glob pattern, asset_name is ignored if this is true'
+  draft:
+    description: 'if true, marks the release as a draft'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,11 +32,11 @@ function get_release_by_tag(tag, octokit, context, draft) {
                 // if there is a draft release already, use that 
                 if (draft) {
                     const releases = yield octokit.repos.listReleases(Object.assign({}, context.repo));
-                    core.debug(`Found ${releases.length} releases, looking for draft release to piggyback..`);
-                    for (let i = 0; i < releases.length; i += 1) {
-                        const release = releases[i];
-                        if (release.data.draft) {
-                            core.debug(`Found draft release in repo, name: ${release.data.name}`);
+                    core.debug(`Found ${releases.data.length} releases, looking for draft release to piggyback..`);
+                    for (let i = 0; i < releases.data.length; i += 1) {
+                        const release = releases.data[i];
+                        if (release.draft) {
+                            core.debug(`Found draft release in repo, name: ${release.name}`);
                             return release;
                         }
                     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,6 +18,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs = __importStar(require("fs"));
 const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
+const path = __importStar(require("path"));
+const glob = require("glob");
 function get_release_by_tag(tag, octokit, context) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -38,7 +40,12 @@ function get_release_by_tag(tag, octokit, context) {
 }
 function upload_to_release(release, file, asset_name, tag, overwrite, octokit, context) {
     return __awaiter(this, void 0, void 0, function* () {
-        const file_size = fs.statSync(file).size;
+        const stat = fs.statSync(file);
+        if (!stat.isFile()) {
+            core.debug(`Skipping ${file}, since its not a file`);
+            return;
+        }
+        const file_size = stat.size;
         const file_bytes = fs.readFileSync(file);
         // Check for duplicates.
         const assets = yield octokit.repos.listAssetsForRelease(Object.assign({}, context.repo, { release_id: release.data.id }));
@@ -73,16 +80,29 @@ function run() {
         try {
             const token = core.getInput('repo_token', { required: true });
             const file = core.getInput('file', { required: true });
-            const asset_name = core.getInput('asset_name', { required: true });
+            const file_glob = core.getInput('file_glob');
             const tag = core.getInput('tag', { required: true }).replace("refs/tags/", "");
             const overwrite = core.getInput('overwrite');
-            if (!fs.existsSync(file)) {
-                core.setFailed(`File ${file} wasn't found.`);
-            }
             const octokit = new github.GitHub(token);
             const context = github.context;
             const release = yield get_release_by_tag(tag, octokit, context);
-            yield upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
+            if (file_glob === "true") {
+                const files = glob.sync(file);
+                if (files.length > 0) {
+                    for (let i = 0; i < files.length; i += 1) {
+                        const file = files[i];
+                        const asset_name = path.basename(file);
+                        yield upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
+                    }
+                }
+                else {
+                    core.setFailed("No files matching the glob pattern found.");
+                }
+            }
+            else {
+                const asset_name = core.getInput('asset_name', { required: true });
+                yield upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
+            }
         }
         catch (error) {
             core.setFailed(error.message);

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,8 +37,8 @@ function get_release_by_tag(tag, octokit, context, draft) {
                         const release = releases.data[i];
                         if (release.draft) {
                             core.debug(JSON.stringify(release));
-                            core.debug(`Found draft release in repo, name: ${release.name}`);
-                            return release;
+                            core.debug(`Found draft release in repo, tag_name: ${release.tag_name}`);
+                            return { data: release };
                         }
                     }
                 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,7 +36,6 @@ function get_release_by_tag(tag, octokit, context, draft) {
                     for (let i = 0; i < releases.data.length; i += 1) {
                         const release = releases.data[i];
                         if (release.draft) {
-                            core.debug(JSON.stringify(release));
                             core.debug(`Found draft release in repo, tag_name: ${release.tag_name}`);
                             return { data: release };
                         }

--- a/lib/main.js
+++ b/lib/main.js
@@ -20,7 +20,7 @@ const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
 const path = __importStar(require("path"));
 const glob = require("glob");
-function get_release_by_tag(tag, octokit, context) {
+function get_release_by_tag(tag, octokit, context, draft) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.debug(`Getting release by tag ${tag}.`);
@@ -30,7 +30,7 @@ function get_release_by_tag(tag, octokit, context) {
             // If this returns 404, we need to create the release first.
             if (error.status === 404) {
                 core.debug(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
-                return yield octokit.repos.createRelease(Object.assign({}, context.repo, { tag_name: tag }));
+                return yield octokit.repos.createRelease(Object.assign({}, context.repo, { tag_name: tag, draft }));
             }
             else {
                 throw error;
@@ -83,16 +83,17 @@ function run() {
             const file_glob = core.getInput('file_glob');
             const tag = core.getInput('tag', { required: true }).replace("refs/tags/", "");
             const overwrite = core.getInput('overwrite');
+            const draft = core.getInput('draft');
             const octokit = new github.GitHub(token);
             const context = github.context;
-            const release = yield get_release_by_tag(tag, octokit, context);
+            const release = yield get_release_by_tag(tag, octokit, context, draft === "true");
             if (file_glob === "true") {
                 const files = glob.sync(file);
                 if (files.length > 0) {
                     for (let i = 0; i < files.length; i += 1) {
-                        const file = files[i];
-                        const asset_name = path.basename(file);
-                        yield upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
+                        const item = files[i];
+                        const asset_name = path.basename(item);
+                        yield upload_to_release(release, item, asset_name, tag, overwrite, octokit, context);
                     }
                 }
                 else {

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,6 +29,19 @@ function get_release_by_tag(tag, octokit, context, draft) {
         catch (error) {
             // If this returns 404, we need to create the release first.
             if (error.status === 404) {
+                // if there is a draft release already, use that 
+                if (draft) {
+                    const releases = yield octokit.repos.listReleases(Object.assign({}, context.repo));
+                    core.debug(`Found ${releases.length} releases, looking for draft release to piggyback..`);
+                    for (let i = 0; i < releases.length; i += 1) {
+                        const release = releases[i];
+                        if (release.data.draft) {
+                            core.debug(`Found draft release in repo, name: ${release.data.name}`);
+                            return release;
+                        }
+                    }
+                }
+                // otherwise create a release (draft if necessary)
                 core.debug(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
                 return yield octokit.repos.createRelease(Object.assign({}, context.repo, { tag_name: tag, draft }));
             }

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,7 @@ function get_release_by_tag(tag, octokit, context, draft) {
                     for (let i = 0; i < releases.data.length; i += 1) {
                         const release = releases.data[i];
                         if (release.draft) {
+                            core.debug(JSON.stringify(release));
                             core.debug(`Found draft release in repo, name: ${release.name}`);
                             return release;
                         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -852,8 +852,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -934,7 +933,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1194,9 +1192,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
       "dev": true,
       "optional": true
     },
@@ -1209,8 +1207,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -1788,8 +1785,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -2378,7 +2374,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2407,9 +2402,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -2561,7 +2556,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2570,8 +2564,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -3681,7 +3674,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4128,8 +4120,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.0.0",
-    "@actions/github": "^1.0.0"
+    "@actions/github": "^1.0.0",
+    "glob": "^7.1.4"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,6 @@ async function get_release_by_tag(tag: string, octokit: any, context: any, draft
                 for (let i = 0; i < releases.data.length; i += 1) {
                     const release = releases.data[i];
                     if (release.draft) {
-                        core.debug(JSON.stringify(release));
                         core.debug(`Found draft release in repo, tag_name: ${release.tag_name}`)
                         return { data: release };
                     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
+import * as path from 'path';
+
+const glob = require("glob")
 
 async function get_release_by_tag(tag: string, octokit: any, context: any): Promise<any> {
     try {
@@ -24,7 +27,12 @@ async function get_release_by_tag(tag: string, octokit: any, context: any): Prom
 }
 
 async function upload_to_release(release: any, file: string, asset_name: string, tag: string, overwrite: string, octokit: any, context: any) {
-    const file_size = fs.statSync(file).size;
+    const stat = fs.statSync(file);
+    if (!stat.isFile()) {
+        core.debug(`Skipping ${file}, since its not a file`);
+        return;
+    }
+    const file_size = stat.size;
     const file_bytes = fs.readFileSync(file);
 
     // Check for duplicates.
@@ -64,19 +72,31 @@ async function run() {
     try {
         const token = core.getInput('repo_token', { required: true });
         const file = core.getInput('file', { required: true });
-        const asset_name = core.getInput('asset_name', { required: true });
+        const file_glob = core.getInput('file_glob');
         const tag = core.getInput('tag', { required: true }).replace("refs/tags/", "");
         const overwrite = core.getInput('overwrite');
 
-        if (!fs.existsSync(file)) {
-            core.setFailed(`File ${file} wasn't found.`);
-        }
-
         const octokit = new github.GitHub(token);
         const context = github.context;
-
         const release = await get_release_by_tag(tag, octokit, context);
-        await upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
+
+        if (file_glob === "true") {
+            const files = glob.sync(file);
+            if (files.length > 0) {
+                for (let i = 0; i < files.length; i += 1) {
+                    const file = files[i];
+                    const asset_name = path.basename(file);
+                    await upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
+                }
+            }
+            else {
+                core.setFailed("No files matching the glob pattern found.");
+            }
+        }
+        else {
+            const asset_name = core.getInput('asset_name', { required: true });
+            await upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
+        }
     } catch (error) {
         core.setFailed(error.message);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ async function get_release_by_tag(tag: string, octokit: any, context: any, draft
                 for (let i = 0; i < releases.data.length; i += 1) {
                     const release = releases.data[i];
                     if (release.draft) {
+                        core.debug(JSON.stringify(release));
                         core.debug(`Found draft release in repo, name: ${release.name}`)
                         return release;
                     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,8 +25,8 @@ async function get_release_by_tag(tag: string, octokit: any, context: any, draft
                     const release = releases.data[i];
                     if (release.draft) {
                         core.debug(JSON.stringify(release));
-                        core.debug(`Found draft release in repo, name: ${release.name}`)
-                        return release;
+                        core.debug(`Found draft release in repo, tag_name: ${release.tag_name}`)
+                        return { data: release };
                     }
                 }
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,11 +20,11 @@ async function get_release_by_tag(tag: string, octokit: any, context: any, draft
                 const releases = await octokit.repos.listReleases({
                     ...context.repo,
                 });
-                core.debug(`Found ${releases.length} releases, looking for draft release to piggyback..`)
-                for (let i = 0; i < releases.length; i += 1) {
-                    const release = releases[i];
-                    if (release.data.draft) {
-                        core.debug(`Found draft release in repo, name: ${release.data.name}`)
+                core.debug(`Found ${releases.data.length} releases, looking for draft release to piggyback..`)
+                for (let i = 0; i < releases.data.length; i += 1) {
+                    const release = releases.data[i];
+                    if (release.draft) {
+                        core.debug(`Found draft release in repo, name: ${release.name}`)
                         return release;
                     }
                 }


### PR DESCRIPTION
hi @svenstaro, thanks for writing such a useful action!

i have been trying to convert my [project](https://github.com/sandiz/rs-manager) to use github actions from travis-ci. Couple of features that were in travis-ci were missing here so i decided to add it.

This PR 
 - adds support for file glob patterns, which allows uploading multiple files to github release that match a pattern 
 - adds the ability to mark a new release as draft or use an existing draft release if its already present.

I have tested the action in my project and it has been working great so far. Here's my workflow [yaml](https://github.com/sandiz/rs-manager/blob/master/.github/workflows/main.yml) for your perusal

Relevant snippet:
```yaml
- uses: sandiz/upload-release-action@releases/v1
  with:
        repo_token: ${{ secrets.GITHUB_TOKEN }}
        file: 'release-builds/Rocksmith*'
        file_glob: true
        tag: 'github-ci-build'
        overwrite: true
        draft: true
```

Let me know if you are accepting PR's! 😇 