### PR TITLE
Support $tag substitution in asset names

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -20,6 +20,6 @@ jobs:
       # Ensure no changes, but ignore node_modules dir since dev/fresh ci deps installed.
       run: |
         git diff --exit-code --stat -- . ':!node_modules' \
-        || (echo "##[error] found changed files after build. please 'npm run build && npm run format'" \
+        || (echo "##[error] found changed files after build. please 'npm install && npm run build'" \
                  "and check in all changes" \
             && exit 1)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ You must provide:
 
 - `repo_token`: Usually you'll want to set this to `${{ secrets.GITHUB_TOKEN }}`
 - `file`: A local file to be uploaded as the asset.
-- `asset_name`: The name the file gets as an asset on a release.
-- `tag`: The tag to uploaded into. If you want the current event's tag, use `${{ github.ref }}`
+- `asset_name`: The name the file gets as an asset on a release. Use `$tag` to include the tag name.
+- `tag`: The tag to uploaded into. If you want the current event's tag, use `${{ github.ref }}` (the `refs/tags/` prefix will be automatically stripped).
 - `overwrite`: If an asset with the same name already exists, overwrite it.
 
 Optional Arguments

--- a/lib/main.js
+++ b/lib/main.js
@@ -99,7 +99,7 @@ function run() {
                 }
             }
             else {
-                const asset_name = core.getInput('asset_name', { required: true });
+                const asset_name = core.getInput('asset_name', { required: true }).replace(/\$tag/g, tag);
                 yield upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ async function run() {
             }
         }
         else {
-            const asset_name = core.getInput('asset_name', { required: true });
+            const asset_name = core.getInput('asset_name', { required: true }).replace(/\$tag/g, tag);
             await upload_to_release(release, file, asset_name, tag, overwrite, octokit, context);
         }
     } catch (error) {


### PR DESCRIPTION
The use case is to upload files with the version embedded within, without needing to pre-process `github.ref` ourselves.

I didn't both implementing the ability to escape `$ref` in a string as I can't really imagine people needing to. But if you'd like me to implement this (eg by allowing `$$ref` or `\$ref`) I can.