### PR TITLE
Strip refs/heads/ from the input tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You must provide:
 
 - `repo_token`: Usually you'll want to set this to `${{ secrets.GITHUB_TOKEN }}`.
 - `file`: A local file to be uploaded as the asset.
-- `tag`: The tag to upload into. If you want the current event's tag, use `${{ github.ref }}` (the `refs/tags/` prefix will be automatically stripped).
+- `tag`: The tag to upload into. If you want the current event's tag or branch name, use `${{ github.ref }}` (the `refs/tags/` and `refs/heads/` prefixes will be automatically stripped).
 
 Optional Arguments
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ async function run(): Promise<void> {
     // Get the inputs from the workflow file: https://github.com/actions/toolkit/tree/master/packages/core#inputsoutputs
     const token = core.getInput('repo_token', {required: true})
     const file = core.getInput('file', {required: true})
-    const tag = core.getInput('tag', {required: true}).replace('refs/tags/', '')
+    const tag = core.getInput('tag', {required: true}).replace('refs/tags/', '').replace('refs/heads/', '')
 
     const file_glob = core.getInput('file_glob') == 'true' ? true : false
     const overwrite = core.getInput('overwrite') == 'true' ? true : false


### PR DESCRIPTION
This patch strips `refs/heads/` from the input tag to make it easier to
use the action with pushes on branches.