### PR TITLE
GH-24: Support for creating a new GH release in a foreign repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Optional Arguments
 - `overwrite`: If an asset with the same name already exists, overwrite it (Default: `false`).
 - `prerelease`: Mark the release as a pre-release (Default: `false`).
 - `release_name`: Explicitly set a release name. (Defaults: implicitly same as `tag` via GitHub API).
-- `body`: Content of the release text (Defaut: `""`).
+- `body`: Content of the release text (Default: `""`).
+- `repo_name`: Specify the name of the GitHub repository in which the GitHub release will be created, edited, and deleted. If the repository is other than the current, it is required to create a personal access token with `repo`, `user`, `admin:repo_hook` scopes to the foreign repository and add it as a secret. (Default: current repository).
 
 ## Output variables
 
@@ -101,12 +102,14 @@ jobs:
 ```
 
 Example with `file_glob`:
+
 ```yaml
 name: Publish
 on:
   push:
     tags:
       - '*'
+
 jobs:
   build:
     name: Publish binaries
@@ -123,6 +126,39 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
+```
+
+Example for creating a release in a foreign repository using `repo_name`:
+
+```yaml
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Publish binaries
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --release
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_name: owner/repository-name
+        # A personal access token for the GitHub repository in which the release will be created and edited.
+        # It is recommended to create the access token with the following scopes: `repo, user, admin:repo_hook`.
+        repo_token: ${{ secrets.YOUR_PERSONAL_ACCESS_TOKEN }}
+        file: target/release/mything
+        asset_name: mything
+        tag: ${{ github.ref }}
+        overwrite: true
+        body: "This is my release text"
 ```
 
 ## Releasing

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,8 @@ inputs:
     description: 'Explicitly set a release name. Defaults to empty which will cause the release to take the tag as name on GitHub.'
   body:
     description: 'Content of the release text. Empty by default.'
+  repo_name:
+    description: 'Specify the name of the GitHub repository in which the GitHub release will be created, edited, and deleted. If the repository is other than the current, it is required to create a personal access token with `repo`, `user`, `admin:repo_hook` scopes to the foreign repository and add it as a secret. Defaults to the current repository'
 outputs:
   browser_download_url:
     description: 'The publicly available URL of the asset.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2205,13 +2205,13 @@ function get_release_by_tag(tag, prerelease, release_name, body, octokit) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.debug(`Getting release by tag ${tag}.`);
-            return yield octokit.repos.getReleaseByTag(Object.assign(Object.assign({}, github.context.repo), { tag: tag }));
+            return yield octokit.repos.getReleaseByTag(Object.assign(Object.assign({}, repo()), { tag: tag }));
         }
         catch (error) {
             // If this returns 404, we need to create the release first.
             if (error.status === 404) {
                 core.debug(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
-                return yield octokit.repos.createRelease(Object.assign(Object.assign({}, github.context.repo), { tag_name: tag, prerelease: prerelease, name: release_name, body: body }));
+                return yield octokit.repos.createRelease(Object.assign(Object.assign({}, repo()), { tag_name: tag, prerelease: prerelease, name: release_name, body: body }));
             }
             else {
                 throw error;
@@ -2229,12 +2229,12 @@ function upload_to_release(release, file, asset_name, tag, overwrite, octokit) {
         const file_size = stat.size;
         const file_bytes = fs.readFileSync(file);
         // Check for duplicates.
-        const assets = yield octokit.repos.listReleaseAssets(Object.assign(Object.assign({}, github.context.repo), { release_id: release.data.id }));
+        const assets = yield octokit.repos.listReleaseAssets(Object.assign(Object.assign({}, repo()), { release_id: release.data.id }));
         const duplicate_asset = assets.data.find(a => a.name === asset_name);
         if (duplicate_asset !== undefined) {
             if (overwrite) {
                 core.debug(`An asset called ${asset_name} already exists in release ${tag} so we'll overwrite it.`);
-                yield octokit.repos.deleteReleaseAsset(Object.assign(Object.assign({}, github.context.repo), { asset_id: duplicate_asset.id }));
+                yield octokit.repos.deleteReleaseAsset(Object.assign(Object.assign({}, repo()), { asset_id: duplicate_asset.id }));
             }
             else {
                 core.setFailed(`An asset called ${asset_name} already exists.`);
@@ -2256,6 +2256,25 @@ function upload_to_release(release, file, asset_name, tag, overwrite, octokit) {
         });
         return uploaded_asset.data.browser_download_url;
     });
+}
+function repo() {
+    const repo_name = core.getInput('repo_name');
+    // If we're not targeting a foreign repository, we can just return immediately and don't have to do extra work.
+    if (!repo_name) {
+        return github.context.repo;
+    }
+    const owner = repo_name.substr(0, repo_name.indexOf('/'));
+    if (!owner) {
+        throw new Error(`Could not extract 'owner' from 'repo_name': ${repo_name}.`);
+    }
+    const repo = repo_name.substr(repo_name.indexOf('/') + 1);
+    if (!repo) {
+        throw new Error(`Could not extract 'repo' from 'repo_name': ${repo_name}.`);
+    }
+    return {
+        owner,
+        repo
+    };
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {


### PR DESCRIPTION
What is does:

This PR allows creating a GitHub release in a foreign repository. Inspired by [_GitHub Release task_](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azure-devops) Azure task.

As PoC, I set up two repositories and crafted a release from one into the other:
 - https://github.com/kittaakos/upload-release-action--host (hosts the GH action)
 - https://github.com/kittaakos/upload-release-action--target (the target of the GH release)

Here is an overview of the required, additional secrets:

![Screen Shot 2020-08-27 at 14 37 11](https://user-images.githubusercontent.com/1405703/91442915-de32ac00-e872-11ea-879f-26e4e0b2cf85.jpg)


Here is the workflow that has created the new GH release:
 - https://github.com/kittaakos/upload-release-action--host/runs/1036474894?check_suite_focus=true

Here is the GH release:
 - https://github.com/kittaakos/upload-release-action--target/releases/tag/0.0.3

Please review. Thank you!

----

To be able to manage foreign repositories.
The `owner` and `repo` is extracted from the `repo_name`.
Otherwise, it uses the current repository.

Closes #24

Signed-off-by: Akos Kitta <kittaakos@typefox.io>