### PR TITLE
GH-26: Fixed ignored `release_name` option.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2211,7 +2211,7 @@ function get_release_by_tag(tag, prerelease, release_name, body, octokit) {
             // If this returns 404, we need to create the release first.
             if (error.status === 404) {
                 core.debug(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
-                return yield octokit.repos.createRelease(Object.assign(Object.assign({}, github.context.repo), { tag_name: tag, prerelease: prerelease, release_name: release_name, body: body }));
+                return yield octokit.repos.createRelease(Object.assign(Object.assign({}, github.context.repo), { tag_name: tag, prerelease: prerelease, name: release_name, body: body }));
             }
             else {
                 throw error;
@@ -2263,7 +2263,10 @@ function run() {
             // Get the inputs from the workflow file: https://github.com/actions/toolkit/tree/master/packages/core#inputsoutputs
             const token = core.getInput('repo_token', { required: true });
             const file = core.getInput('file', { required: true });
-            const tag = core.getInput('tag', { required: true }).replace('refs/tags/', '').replace('refs/heads/', '');
+            const tag = core
+                .getInput('tag', { required: true })
+                .replace('refs/tags/', '')
+                .replace('refs/heads/', '');
             const file_glob = core.getInput('file_glob') == 'true' ? true : false;
             const overwrite = core.getInput('overwrite') == 'true' ? true : false;
             const prerelease = core.getInput('prerelease') == 'true' ? true : false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "upload-release-action",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ async function get_release_by_tag(
         ...github.context.repo,
         tag_name: tag,
         prerelease: prerelease,
-        release_name: release_name,
+        name: release_name,
         body: body
       })
     } else {


### PR DESCRIPTION
`name` should be used when creating a new release.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----

What it does:
 - This PR fixes the ignored `repo_name` property when creating a new GH release: `repo_name` was incorrectly used instead of `name`. [Closes #26]
 - Also, I committed the generated `package-lock.json` file with the desired `2.1.0` version.

PoC:
 - The test workflow: https://github.com/kittaakos/test-for-upload-release-action-GH-26/blob/master/.github/workflows/build.yml#L22
 - And the test GH release: https://github.com/kittaakos/test-for-upload-release-action-GH-26/releases/tag/0.0.1

@svenstaro can you please review the changes? Thank you!