### PR TITLE
[doc]: Fixed the version in the examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
     - name: Build
       run: cargo build --release
     - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@2.2.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: target/release/mything
@@ -93,7 +93,7 @@ jobs:
     - name: Build
       run: cargo build --release --locked
     - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@2.2.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: target/release/${{ matrix.artifact_name }}
@@ -119,7 +119,7 @@ jobs:
     - name: Build
       run: cargo build --release
     - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@2.2.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: target/release/my*
@@ -148,7 +148,7 @@ jobs:
     - name: Build
       run: cargo build --release
     - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@2.2.0
       with:
         repo_name: owner/repository-name
         # A personal access token for the GitHub repository in which the release will be created and edited.


### PR DESCRIPTION
The releases do not have the`v` prefix before the semver; hence the
examples do not work if someone copies it from the doc.

See the [releases](https://github.com/svenstaro/upload-release-action/releases) and the error if someone copy-pastes the examples:
```
Error: Unable to resolve action `svenstaro/upload-release-action@v2.2.0`, unable to find version `v2.2.0`
```

This PR tries to improve the documentation. Please review, thank you!

Signed-off-by: Akos Kitta <kittaakos@typefox.io>