### PR TITLE
Add defaults to commonly set fields to reduce setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ It runs on all operating systems types offered by GitHub.
 
 You must provide:
 
-- `repo_token`: Usually you'll want to set this to `${{ secrets.GITHUB_TOKEN }}`.
 - `file`: A local file to be uploaded as the asset.
-- `tag`: The tag to upload into. If you want the current event's tag or branch name, use `${{ github.ref }}` (the `refs/tags/` and `refs/heads/` prefixes will be automatically stripped).
 
 Optional Arguments
 
+- `repo_token`: Defaults to `github.token`.
+- `tag`: The tag to upload into. If you want the current event's tag or branch name, use `${{ github.ref }}` (the `refs/tags/` and `refs/heads/` prefixes will be automatically stripped). Defaults to `github.ref`.
 - `asset_name`: The name the file gets as an asset on a release. Use `$tag` to include the tag name. When not provided it will default to the filename.
                 This is not used if `file_glob` is set to `true`.
 - `file_glob`: If set to true, the file argument can be a glob pattern (`asset_name` is ignored in this case) (Default: `false`)

--- a/action.yml
+++ b/action.yml
@@ -8,12 +8,14 @@ inputs:
   repo_token:
     description: 'GitHub token.'
     required: true
+    default: ${{ github.token }}
   file:
     description: 'Local file to upload.'
     required: true
   tag:
     description: 'Tag to use as a release.'
     required: true
+    default: ${{ github.ref }}
   asset_name:
     description: 'Name of the asset. When not provided will use the file name. Unused if file_glob is set to "true".'
   overwrite:


### PR DESCRIPTION
### What
Add defaults values for the GitHub token and the tag that are set to commonly set fields.

### Why
Reduce the number of required fields. For most users these defaults will be perfect and they reduce setup.