### PR TITLE
Use the `@file` mechanism of octokit-5

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39,7 +39,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const fs = __importStar(__nccwpck_require__(7147));
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const path = __importStar(__nccwpck_require__(1017));
@@ -69,13 +68,6 @@ function get_release_by_tag(tag, prerelease, release_name, body, octokit) {
 }
 function upload_to_release(release, file, asset_name, tag, overwrite, octokit) {
     return __awaiter(this, void 0, void 0, function* () {
-        const stat = fs.statSync(file);
-        if (!stat.isFile()) {
-            core.debug(`Skipping ${file}, since its not a file`);
-            return;
-        }
-        const file_size = stat.size;
-        const file_bytes = fs.readFileSync(file).toString('binary');
         // Check for duplicates.
         const assets = yield octokit.paginate(repoAssets, Object.assign(Object.assign({}, repo()), { release_id: release.data.id }));
         const duplicate_asset = assets.find(a => a.name === asset_name);
@@ -93,10 +85,7 @@ function upload_to_release(release, file, asset_name, tag, overwrite, octokit) {
             core.debug(`No pre-existing asset called ${asset_name} found in release ${tag}. All good.`);
         }
         core.debug(`Uploading ${file} to ${asset_name} in release ${tag}.`);
-        const uploaded_asset = yield octokit.request(uploadAssets, Object.assign(Object.assign({}, repo()), { release_id: release.data.id, url: release.data.upload_url, name: asset_name, data: file_bytes, headers: {
-                'content-type': 'binary/octet-stream',
-                'content-length': file_size
-            } }));
+        const uploaded_asset = yield octokit.request(uploadAssets, Object.assign(Object.assign({}, repo()), { release_id: release.data.id, name: asset_name, data: '@' + file }));
         return uploaded_asset.data.browser_download_url;
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs'
 import {Octokit} from '@octokit/core'
 import {Endpoints} from '@octokit/types'
 import * as core from '@actions/core'
@@ -60,14 +59,6 @@ async function upload_to_release(
   overwrite: boolean,
   octokit: ReturnType<(typeof github)['getOctokit']>
 ): Promise<undefined | string> {
-  const stat = fs.statSync(file)
-  if (!stat.isFile()) {
-    core.debug(`Skipping ${file}, since its not a file`)
-    return
-  }
-  const file_size = stat.size
-  const file_bytes = fs.readFileSync(file).toString('binary')
-
   // Check for duplicates.
   const assets: RepoAssetsResp = await octokit.paginate(repoAssets, {
     ...repo(),
@@ -97,13 +88,8 @@ async function upload_to_release(
   const uploaded_asset: UploadAssetResp = await octokit.request(uploadAssets, {
     ...repo(),
     release_id: release.data.id,
-    url: release.data.upload_url,
     name: asset_name,
-    data: file_bytes,
-    headers: {
-      'content-type': 'binary/octet-stream',
-      'content-length': file_size
-    }
+    data: '@' + file
   })
   return uploaded_asset.data.browser_download_url
 }


### PR DESCRIPTION
Adhere to the Octokit-5 spec:
``` js
// Octokit.js
// https://github.com/octokit/core.js#readme
const octokit = new Octokit({
  auth: 'YOUR-TOKEN'
})

await octokit.request('POST /repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}', {
  owner: 'OWNER',
  repo: 'REPO',
  release_id: 'RELEASE_ID',
  data: '@release-asset.gz'
})
```

TypeScript also insists on filling in the `name:` slot, so leave that in.