### PR TITLE
Add `make_latest` param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         tag: ci-test-${{ matrix.os }}-${{ github.run_id }}
         overwrite: true
         prerelease: true
+        make_latest: true
         body: "rofl lol test%0Aianal %25 fubar"
     - name: Check that the uploaded asset is readable
       uses: actions/github-script@v2
@@ -47,6 +48,7 @@ jobs:
             tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}",
           })
           assert.deepStrictEqual(release.data.prerelease, true)
+          assert.deepStrictEqual(release.data.make_latest, true)
           assert.deepStrictEqual(release.data.body, "rofl lol test\nianal % fubar")
           assert.deepStrictEqual(release.data.assets[0].name, "TEST.md")
           const actual = child_process.execSync(`curl -Ls ${release.data.assets[0].browser_download_url}`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add `make_latest` input parameter. Can be set to `false` to prevent the created release from being marked as the latest release for the repository.
+
 ## [2.5.0] - 2023-02-21
 - Add retry to upload release [#96](https://github.com/svenstaro/upload-release-action/pull/96) (thanks @sonphantrung)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Optional Arguments
 - `file_glob`: If set to true, the file argument can be a glob pattern (`asset_name` is ignored in this case) (Default: `false`)
 - `overwrite`: If an asset with the same name already exists, overwrite it (Default: `false`).
 - `prerelease`: Mark the release as a pre-release (Default: `false`).
+- `make_latest`: Mark the release as the latest release for the repository (Default: `true`).
 - `release_name`: Explicitly set a release name. (Defaults: implicitly same as `tag` via GitHub API).
 - `body`: Content of the release text (Default: `""`).
 - `repo_name`: Specify the name of the GitHub repository in which the GitHub release will be created, edited, and deleted. If the repository is other than the current, it is required to create a personal access token with `repo`, `user`, `admin:repo_hook` scopes to the foreign repository and add it as a secret. (Default: current repository).

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,8 @@ inputs:
     description: 'If true the file can be a glob pattern, asset_name is ignored if this is true.'
   prerelease:
     description: 'Mark the release as a pre-release. Defaults to "false".'
+  make_latest:
+    description: 'Mark the release the latest release for the repository. Defaults to "true".'
   release_name:
     description: 'Explicitly set a release name. Defaults to empty which will cause the release to take the tag as name on GitHub.'
   body:

--- a/dist/index.js
+++ b/dist/index.js
@@ -50,7 +50,7 @@ const createRelease = 'POST /repos/{owner}/{repo}/releases';
 const repoAssets = 'GET /repos/{owner}/{repo}/releases/{release_id}/assets';
 const uploadAssets = 'POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}';
 const deleteAssets = 'DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}';
-function get_release_by_tag(tag, prerelease, release_name, body, octokit) {
+function get_release_by_tag(tag, prerelease, make_latest, release_name, body, octokit) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.debug(`Getting release by tag ${tag}.`);
@@ -60,7 +60,7 @@ function get_release_by_tag(tag, prerelease, release_name, body, octokit) {
             // If this returns 404, we need to create the release first.
             if (error.status === 404) {
                 core.debug(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
-                return yield octokit.request(createRelease, Object.assign(Object.assign({}, repo()), { tag_name: tag, prerelease: prerelease, name: release_name, body: body }));
+                return yield octokit.request(createRelease, Object.assign(Object.assign({}, repo()), { tag_name: tag, prerelease: prerelease, make_latest: make_latest, name: release_name, body: body }));
             }
             else {
                 throw error;
@@ -137,6 +137,7 @@ function run() {
             const file_glob = core.getInput('file_glob') == 'true' ? true : false;
             const overwrite = core.getInput('overwrite') == 'true' ? true : false;
             const prerelease = core.getInput('prerelease') == 'true' ? true : false;
+            const make_latest = core.getInput('make_latest') != 'false' ? true : false;
             const release_name = core.getInput('release_name');
             const body = core
                 .getInput('body')
@@ -144,7 +145,7 @@ function run() {
                 .replace(/%0D/gi, '\r')
                 .replace(/%25/g, '%');
             const octokit = github.getOctokit(token);
-            const release = yield get_release_by_tag(tag, prerelease, release_name, body, octokit);
+            const release = yield get_release_by_tag(tag, prerelease, make_latest, release_name, body, octokit);
             if (file_glob) {
                 const files = glob.sync(file);
                 if (files.length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ type UploadAssetResp = Endpoints[typeof uploadAssets]['response']
 async function get_release_by_tag(
   tag: string,
   prerelease: boolean,
+  make_latest: boolean,
   release_name: string,
   body: string,
   octokit: Octokit
@@ -44,6 +45,7 @@ async function get_release_by_tag(
         ...repo(),
         tag_name: tag,
         prerelease: prerelease,
+        make_latest: make_latest,
         name: release_name,
         body: body
       })
@@ -149,6 +151,7 @@ async function run(): Promise<void> {
     const file_glob = core.getInput('file_glob') == 'true' ? true : false
     const overwrite = core.getInput('overwrite') == 'true' ? true : false
     const prerelease = core.getInput('prerelease') == 'true' ? true : false
+    const make_latest = core.getInput('make_latest') != 'false' ? true : false
     const release_name = core.getInput('release_name')
     const body = core
       .getInput('body')
@@ -160,6 +163,7 @@ async function run(): Promise<void> {
     const release = await get_release_by_tag(
       tag,
       prerelease,
+      make_latest,
       release_name,
       body,
       octokit


### PR DESCRIPTION
Adds a new `make_latest` param, which is supported by the [Create a release](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release) API endpoint, and determines whether the release should be marked as the new latest release for the repository.

The action param defaults to `true`, so the existing behavior isn’t altered. (The API param also defaults to `true`.)