### PR TITLE
Feat: Allow upload to draft release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,9 +38,13 @@ inputs:
     description: 'Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository\"s default branch (usually `main`).'
   repo_name:
     description: 'Specify the name of the GitHub repository in which the GitHub release will be created, edited, and deleted. If the repository is other than the current, it is required to create a personal access token with `repo`, `user`, `admin:repo_hook` scopes to the foreign repository and add it as a secret. Defaults to the current repository'
+  draft_id:
+    description: 'Specify the ID of the draft release you want to upload to.'
 outputs:
   browser_download_url:
     description: 'The publicly available URL of the asset.'
+  draft_id:
+    description: 'The ID of the draft release created.'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {retry} from '@lifeomic/attempt'
 
 const getRef = 'GET /repos/{owner}/{repo}/git/ref/{ref}'
 const releaseByTag = 'GET /repos/{owner}/{repo}/releases/tags/{tag}'
+const releaseByID = 'GET /repos/{owner}/{repo}/releases/{release_id}'
 const createRelease = 'POST /repos/{owner}/{repo}/releases'
 const updateRelease = 'PATCH /repos/{owner}/{repo}/releases/{release_id}'
 const repoAssets = 'GET /repos/{owner}/{repo}/releases/{release_id}/assets'
@@ -17,6 +18,7 @@ const uploadAssets =
 const deleteAssets = 'DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}'
 
 type ReleaseByTagResp = Endpoints[typeof releaseByTag]['response']
+type ReleaseByIDResp = Endpoints[typeof releaseByID]['response']
 type CreateReleaseResp = Endpoints[typeof createRelease]['response']
 type RepoAssetsResp = Endpoints[typeof repoAssets]['response']['data']
 type UploadAssetResp = Endpoints[typeof uploadAssets]['response']
@@ -33,15 +35,31 @@ async function get_release_by_tag(
   octokit: Octokit,
   overwrite: boolean,
   promote: boolean,
-  target_commit: string
+  target_commit: string,
+  known_draft_id = 0
 ): Promise<ReleaseByTagResp | CreateReleaseResp | UpdateReleaseResp> {
-  let release: ReleaseByTagResp
+  let release: ReleaseByTagResp | ReleaseByIDResp
   try {
-    core.debug(`Getting release by tag ${tag}.`)
-    release = await octokit.request(releaseByTag, {
-      ...repo(),
-      tag: tag
-    })
+    core.debug(`Draft ID: ${known_draft_id}`)
+
+    if (draft === true && known_draft_id !== 0) {
+      // We are working with a draft release and we already created it
+      core.debug(
+        `Getting release by id ${known_draft_id} because we're working with a draft release.`
+      )
+      release = await octokit.request(releaseByID, {
+        ...repo(),
+        release_id: known_draft_id
+      })
+
+      core.debug(`The release has the following ID: ${release.data.id}`)
+    } else {
+      core.debug(`Getting release by tag ${tag}.`)
+      release = await octokit.request(releaseByTag, {
+        ...repo(),
+        tag: tag
+      })
+    }
   } catch (error: any) {
     // If this returns 404, we need to create the release first.
     if (error.status === 404) {
@@ -63,7 +81,7 @@ async function get_release_by_tag(
           }
         }
       }
-      return await octokit.request(createRelease, {
+      const _release = await octokit.request(createRelease, {
         ...repo(),
         tag_name: tag,
         draft: draft,
@@ -73,6 +91,10 @@ async function get_release_by_tag(
         body: body,
         target_commitish: target_commit
       })
+
+      core.setOutput('draft_id', _release.data.id)
+
+      return _release
     } else {
       throw error
     }
@@ -213,6 +235,7 @@ async function run(): Promise<void> {
     const make_latest = core.getInput('make_latest') != 'false' ? true : false
     const release_name = core.getInput('release_name')
     const target_commit = core.getInput('target_commit')
+    const draft_release_id = core.getInput('draft_id')
     const body = core
       .getInput('body')
       .replace(/%0A/gi, '\n')
@@ -230,7 +253,8 @@ async function run(): Promise<void> {
       octokit,
       overwrite,
       promote,
-      target_commit
+      target_commit,
+      Number(draft_release_id)
     )
 
     if (file_glob) {


### PR DESCRIPTION
This PR allows users to upload to an already created release in draft mode.

It adds:

- An input named `draft_id`
- An output named `draft_id`

Since the issue to upload to a release in draft mode affects mostly those using a matrix we cannot integrate a complete logic inside this action.
What we can do however, is to "listen" to an ID and try to upload to it, this needs to already have a release ID before calling this action in draft mode which is honestly not really complicated to do. (see https://github.com/marketplace/actions/release-draft for a dedicated actions or [@alexis-opolka/upload-release-action/master/.../draft-matrix.yml](https://github.com/alexis-opolka/upload-release-action/blob/master/.github/workflows/draft-matrix.yml) for an example using this action in two different jobs)

Fixes #133 