### PR TITLE
Code cleanup

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -88,7 +88,7 @@ function get_release_by_tag(tag, draft, prerelease, make_latest, release_name, b
             // @ts-ignore
             return yield octokit.request(createRelease, Object.assign(Object.assign({}, repo()), { tag_name: tag, draft: draft, prerelease: prerelease, make_latest: make_latest ? 'true' : 'false', name: release_name, body: body, target_commitish: target_commit }));
         }
-        return update_release(promote, release, tag, overwrite, release_name, body, octokit);
+        return yield update_release(promote, release, tag, overwrite, release_name, body, octokit);
     });
 }
 function update_release(promote, release, tag, overwrite, release_name, body, octokit) {
@@ -113,7 +113,7 @@ function update_release(promote, release, tag, overwrite, release_name, body, oc
         }
         if (updateObject) {
             // @ts-ignore
-            return octokit.request(updateRelease, Object.assign(Object.assign(Object.assign({}, repo()), updateObject), { release_id: release.data.id }));
+            return yield octokit.request(updateRelease, Object.assign(Object.assign(Object.assign({}, repo()), updateObject), { release_id: release.data.id }));
         }
         return release;
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -88,6 +88,11 @@ function get_release_by_tag(tag, draft, prerelease, make_latest, release_name, b
             // @ts-ignore
             return yield octokit.request(createRelease, Object.assign(Object.assign({}, repo()), { tag_name: tag, draft: draft, prerelease: prerelease, make_latest: make_latest ? 'true' : 'false', name: release_name, body: body, target_commitish: target_commit }));
         }
+        return update_release(promote, release, tag, overwrite, release_name, body, octokit);
+    });
+}
+function update_release(promote, release, tag, overwrite, release_name, body, octokit) {
+    return __awaiter(this, void 0, void 0, function* () {
         let updateObject;
         if (promote && release.data.prerelease) {
             core.debug(`The ${tag} is a prerelease, promoting it to a release.`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -72,25 +72,21 @@ function get_release_by_tag(tag, draft, prerelease, make_latest, release_name, b
         }
         catch (error) {
             // If this returns 404, we need to create the release first.
-            if (error.status === 404) {
-                core.debug(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
-                if (target_commit) {
-                    try {
-                        yield octokit.request(getRef, Object.assign(Object.assign({}, repo()), { ref: `tags/${tag}` }));
-                        core.warning(`Ignoring target_commit as the tag ${tag} already exists`);
-                    }
-                    catch (tagError) {
-                        if (tagError.status !== 404) {
-                            throw tagError;
-                        }
-                    }
-                }
-                // @ts-ignore
-                return yield octokit.request(createRelease, Object.assign(Object.assign({}, repo()), { tag_name: tag, draft: draft, prerelease: prerelease, make_latest: make_latest ? 'true' : 'false', name: release_name, body: body, target_commitish: target_commit }));
-            }
-            else {
+            if (error.status !== 404)
                 throw error;
+            core.debug(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
+            if (target_commit) {
+                try {
+                    yield octokit.request(getRef, Object.assign(Object.assign({}, repo()), { ref: `tags/${tag}` }));
+                    core.warning(`Ignoring target_commit as the tag ${tag} already exists`);
+                }
+                catch (tagError) {
+                    if (tagError.status !== 404)
+                        throw tagError;
+                }
             }
+            // @ts-ignore
+            return yield octokit.request(createRelease, Object.assign(Object.assign({}, repo()), { tag_name: tag, draft: draft, prerelease: prerelease, make_latest: make_latest ? 'true' : 'false', name: release_name, body: body, target_commitish: target_commit }));
         }
         let updateObject;
         if (promote && release.data.prerelease) {
@@ -187,12 +183,12 @@ function run() {
                 .getInput('tag', { required: true })
                 .replace('refs/tags/', '')
                 .replace('refs/heads/', '');
-            const file_glob = core.getInput('file_glob') == 'true' ? true : false;
-            const overwrite = core.getInput('overwrite') == 'true' ? true : false;
-            const promote = core.getInput('promote') == 'true' ? true : false;
-            const draft = core.getInput('draft') == 'true' ? true : false;
-            const prerelease = core.getInput('prerelease') == 'true' ? true : false;
-            const make_latest = core.getInput('make_latest') != 'false' ? true : false;
+            const file_glob = core.getInput('file_glob') == 'true';
+            const overwrite = core.getInput('overwrite') == 'true';
+            const promote = core.getInput('promote') == 'true';
+            const draft = core.getInput('draft') == 'true';
+            const prerelease = core.getInput('prerelease') == 'true';
+            const make_latest = core.getInput('make_latest') != 'false';
             const release_name = core.getInput('release_name');
             const target_commit = core.getInput('target_commit');
             const body = core

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,7 +74,26 @@ async function get_release_by_tag(
       target_commitish: target_commit
     })
   }
+  return await update_release(
+    promote,
+    release,
+    tag,
+    overwrite,
+    release_name,
+    body,
+    octokit
+  )
+}
 
+async function update_release(
+  promote: boolean,
+  release: ReleaseByTagResp,
+  tag: string,
+  overwrite: boolean,
+  release_name: string,
+  body: string,
+  octokit: Octokit
+): Promise<ReleaseByTagResp | UpdateReleaseResp> {
   let updateObject: Partial<UpdateReleaseParams> | undefined
   if (promote && release.data.prerelease) {
     core.debug(`The ${tag} is a prerelease, promoting it to a release.`)
@@ -99,7 +118,7 @@ async function get_release_by_tag(
   }
   if (updateObject) {
     // @ts-ignore
-    return octokit.request(updateRelease, {
+    return await octokit.request(updateRelease, {
       ...repo(),
       ...updateObject,
       release_id: release.data.id

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,40 +46,35 @@ async function get_release_by_tag(
     })
   } catch (error: any) {
     // If this returns 404, we need to create the release first.
-    if (error.status === 404) {
-      core.debug(
-        `Release for tag ${tag} doesn't exist yet so we'll create it now.`
-      )
-      if (target_commit) {
-        try {
-          await octokit.request(getRef, {
-            ...repo(),
-            ref: `tags/${tag}`
-          })
-          core.warning(
-            `Ignoring target_commit as the tag ${tag} already exists`
-          )
-        } catch (tagError: any) {
-          if (tagError.status !== 404) {
-            throw tagError
-          }
-        }
+    if (error.status !== 404) throw error
+
+    core.debug(
+      `Release for tag ${tag} doesn't exist yet so we'll create it now.`
+    )
+    if (target_commit) {
+      try {
+        await octokit.request(getRef, {
+          ...repo(),
+          ref: `tags/${tag}`
+        })
+        core.warning(`Ignoring target_commit as the tag ${tag} already exists`)
+      } catch (tagError: any) {
+        if (tagError.status !== 404) throw tagError
       }
-      // @ts-ignore
-      return await octokit.request(createRelease, {
-        ...repo(),
-        tag_name: tag,
-        draft: draft,
-        prerelease: prerelease,
-        make_latest: make_latest ? 'true' : 'false',
-        name: release_name,
-        body: body,
-        target_commitish: target_commit
-      })
-    } else {
-      throw error
     }
+    // @ts-ignore
+    return await octokit.request(createRelease, {
+      ...repo(),
+      tag_name: tag,
+      draft: draft,
+      prerelease: prerelease,
+      make_latest: make_latest ? 'true' : 'false',
+      name: release_name,
+      body: body,
+      target_commitish: target_commit
+    })
   }
+
   let updateObject: Partial<UpdateReleaseParams> | undefined
   if (promote && release.data.prerelease) {
     core.debug(`The ${tag} is a prerelease, promoting it to a release.`)
@@ -211,12 +206,12 @@ async function run(): Promise<void> {
       .replace('refs/tags/', '')
       .replace('refs/heads/', '')
 
-    const file_glob = core.getInput('file_glob') == 'true' ? true : false
-    const overwrite = core.getInput('overwrite') == 'true' ? true : false
-    const promote = core.getInput('promote') == 'true' ? true : false
-    const draft = core.getInput('draft') == 'true' ? true : false
-    const prerelease = core.getInput('prerelease') == 'true' ? true : false
-    const make_latest = core.getInput('make_latest') != 'false' ? true : false
+    const file_glob = core.getInput('file_glob') == 'true'
+    const overwrite = core.getInput('overwrite') == 'true'
+    const promote = core.getInput('promote') == 'true'
+    const draft = core.getInput('draft') == 'true'
+    const prerelease = core.getInput('prerelease') == 'true'
+    const make_latest = core.getInput('make_latest') != 'false'
     const release_name = core.getInput('release_name')
     const target_commit = core.getInput('target_commit')
     const body = core


### PR DESCRIPTION
- Simplify string to boolean conversion
- Reduced nesting in get_release_by_tag for non-existent release path
- Split update_release into a separate function

This is in preparation for catching "tried creating a release but it was already created" error, present in several issues