### PR TITLE
Adds the ability to disable duplicate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Optional Arguments
 - `target_commit`: Sets the commit hash or branch for the tag to be based on (Default: the default branch, usually `main`).
 - `body`: Content of the release text (Default: `""`).
 - `repo_name`: Specify the name of the GitHub repository in which the GitHub release will be created, edited, and deleted. If the repository is other than the current, it is required to create a personal access token with `repo`, `user`, `admin:repo_hook` scopes to the foreign repository and add it as a secret. (Default: current repository).
+- `check_duplicates`: Enable or disable the check for existing assets with the same name. If enabled, the action will skip uploading the asset if it already exists. (Default: `true`).
 
 ## Output variables
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
     description: 'Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository\"s default branch (usually `main`).'
   repo_name:
     description: 'Specify the name of the GitHub repository in which the GitHub release will be created, edited, and deleted. If the repository is other than the current, it is required to create a personal access token with `repo`, `user`, `admin:repo_hook` scopes to the foreign repository and add it as a secret. Defaults to the current repository'
+  check_duplicates:
+    description: 'Check for duplicate assets with the same name in the release and skip uploading of those. Defaults to "true".'
+    default: true
 outputs:
   browser_download_url:
     description: 'The publicly available URL of the asset.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -197,7 +197,7 @@ function run() {
             const make_latest = core.getInput('make_latest') != 'false' ? true : false;
             const release_name = core.getInput('release_name');
             const target_commit = core.getInput('target_commit');
-            const check_duplicates = core.getInput('check_duplicates') == 'true' ? true : false;
+            const check_duplicates = core.getInput('check_duplicates') != 'false' ? true : false;
             const body = core
                 .getInput('body')
                 .replace(/%0A/gi, '\n')

--- a/src/main.ts
+++ b/src/main.ts
@@ -223,7 +223,7 @@ async function run(): Promise<void> {
     const release_name = core.getInput('release_name')
     const target_commit = core.getInput('target_commit')
     const check_duplicates =
-      core.getInput('check_duplicates') == 'true' ? true : false
+      core.getInput('check_duplicates') != 'false' ? true : false
     const body = core
       .getInput('body')
       .replace(/%0A/gi, '\n')

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,8 +119,8 @@ async function upload_to_release(
   asset_name: string,
   tag: string,
   overwrite: boolean,
-  octokit: ReturnType<(typeof github)['getOctokit']>
-  check_duplicates: boolean,
+  octokit: ReturnType<(typeof github)['getOctokit']>,
+  check_duplicates: boolean
 ): Promise<undefined | string> {
   const stat = fs.statSync(file)
   if (!stat.isFile()) {
@@ -133,32 +133,32 @@ async function upload_to_release(
     return
   }
 
-    if (check_duplicates) {
-      // Check for duplicates.
-      const assets: RepoAssetsResp = await octokit.paginate(repoAssets, {
-        ...repo(),
-        release_id: release.data.id
-      })
-      const duplicate_asset = assets.find(a => a.name === asset_name)
-      if (duplicate_asset !== undefined) {
-        if (overwrite) {
-          core.debug(
-            `An asset called ${asset_name} already exists in release ${tag} so we'll overwrite it.`
-          )
-          await octokit.request(deleteAssets, {
-            ...repo(),
-            asset_id: duplicate_asset.id
-          })
-        } else {
-          core.setFailed(`An asset called ${asset_name} already exists.`)
-          return duplicate_asset.browser_download_url
-        }
-      } else {
+  if (check_duplicates) {
+    // Check for duplicates.
+    const assets: RepoAssetsResp = await octokit.paginate(repoAssets, {
+      ...repo(),
+      release_id: release.data.id
+    })
+    const duplicate_asset = assets.find(a => a.name === asset_name)
+    if (duplicate_asset !== undefined) {
+      if (overwrite) {
         core.debug(
-          `No pre-existing asset called ${asset_name} found in release ${tag}. All good.`
+          `An asset called ${asset_name} already exists in release ${tag} so we'll overwrite it.`
         )
+        await octokit.request(deleteAssets, {
+          ...repo(),
+          asset_id: duplicate_asset.id
+        })
+      } else {
+        core.setFailed(`An asset called ${asset_name} already exists.`)
+        return duplicate_asset.browser_download_url
       }
+    } else {
+      core.debug(
+        `No pre-existing asset called ${asset_name} found in release ${tag}. All good.`
+      )
     }
+  }
 
   core.debug(`Uploading ${file} to ${asset_name} in release ${tag}.`)
 
@@ -222,7 +222,8 @@ async function run(): Promise<void> {
     const make_latest = core.getInput('make_latest') != 'false' ? true : false
     const release_name = core.getInput('release_name')
     const target_commit = core.getInput('target_commit')
-    const check_duplicates = core.getInput('check_duplicates') == 'true' ? true : false
+    const check_duplicates =
+      core.getInput('check_duplicates') == 'true' ? true : false
     const body = core
       .getInput('body')
       .replace(/%0A/gi, '\n')


### PR DESCRIPTION
# What
Adds an option to disable the duplicate check

# Why
On projects with very large amounts of artifacts, having this enabled can contribute to overuse of the GitHub API and failed builds.  This was happening here:

https://github.com/muttleyxd/clang-tools-static-binaries/pull/70

# How
Add a boolean option with a backward-compatible default, no breaking changes