### PR TITLE
E2E draft tests

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -34,11 +34,14 @@ jobs:
           const assert = require('assert').strict;
 
           // We cannot find drafts by tag
-          const releaseByTag = await github.rest.repos.getReleaseByTag({
-            ...context.repo,
-            tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}"
-          })
-          assert.equal(release, None)
+          try {
+            const release = await github.rest.repos.getReleaseByTag({
+              ...context.repo,
+              tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}"
+            })
+          } catch (error) {
+            assert.equal(error.status, 404)
+          }
           
           // Instead we can find them by ID
           const release = await github.rest.repos.getReleaseById({

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -47,7 +47,7 @@ jobs:
           }
           
           // Instead we can find them by ID
-          const release = await github.rest.repos.getReleaseById({
+          const release = await github.request('GET /repos/{owner}/{repo}/releases/{release_id}', {
             ...context.repo,
             tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}",
             release_id: process.env.DRAFT_ID,

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Make test draft
+      id: make-test-draft
       uses: ./
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -27,6 +28,8 @@ jobs:
 
     - name: Assert draft release get be retrieved
       uses: actions/github-script@v7
+      env:
+        DRAFT_ID: ${{ steps.make-test-draft.outputs.draft_id }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -47,7 +50,7 @@ jobs:
           const release = await github.rest.repos.getReleaseById({
             ...context.repo,
             tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}",
-            release_id: ${{ steps.make-test-draft.outputs.draft_id }}
+            release_id: process.env.DRAFT_ID,
           })
           
           assert.deepStrictEqual(release.data.draft, true)

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -85,13 +85,7 @@ jobs:
           
           assert.deepStrictEqual(release.data.prerelease, true)
           assert.deepStrictEqual(release.data.body, "rofl lol test\nianal % fubar")
-          assert.deepStrictEqual(release.data.assets[0].name, "TEST.md")
-          assert.deepStrictEqual(release.data.assets[1].name, "TEST2.md")
-          const arraybuf = await github.request(release.data.assets[1].browser_download_url)
-          const actual = Buffer.from(arraybuf.data).toString('utf8')
-          console.log(typeof(actual))
-          console.log(typeof(expected))
-          assert.deepStrictEqual(expected, actual)
+          assert.deepStrictEqual(release.data.assets.map(a => a.name), ["TEST.md", "TEST2.md"])
 
     - name: Make test pre-release
       uses: ./

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Make test draft
-      id: make-test-draft
+    - name: Make draft
+      id: make-draft
       uses: ./
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
     - name: Assert draft release get be retrieved
       uses: actions/github-script@v7
       env:
-        DRAFT_ID: ${{ steps.make-test-draft.outputs.draft_id }}
+        DRAFT_ID: ${{ steps.make-draft.outputs.draft_id }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -62,14 +62,14 @@ jobs:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: README.md
         asset_name: TEST2.md
-        draft_id: ${{ steps.make-test-draft.outputs.draft_id }}
-        tag: ci-test-${{ matrix.os }}-${{ github.run_id }}
         draft: true
+        draft_id: ${{ steps.make-draft.outputs.draft_id }}
+        tag: ci-test-${{ matrix.os }}-${{ github.run_id }}
 
     - name: Check that files can be uploaded to existing draft
       uses: actions/github-script@v7
       env:
-        DRAFT_ID: ${{ steps.make-test-draft.outputs.draft_id }}
+        DRAFT_ID: ${{ steps.make-draft.outputs.draft_id }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -83,7 +83,6 @@ jobs:
             release_id: process.env.DRAFT_ID,
           })
           
-          assert.deepStrictEqual(release.data.prerelease, true)
           assert.deepStrictEqual(release.data.body, "rofl lol test\nianal % fubar")
           assert.deepStrictEqual(release.data.assets.map(a => a.name), ["TEST.md", "TEST2.md"])
 

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -15,6 +15,42 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Make test draft
+      uses: ./
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: README.md
+        asset_name: TEST.md
+        tag: ci-test-${{ matrix.os }}-${{ github.run_id }}
+        draft: true
+        body: "rofl lol test%0Aianal %25 fubar"
+
+    - name: Assert draft release get be retrieved
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const fs = require('fs')
+          const assert = require('assert').strict;
+
+          // We cannot find drafts by tag
+          const releaseByTag = await github.rest.repos.getReleaseByTag({
+            ...context.repo,
+            tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}"
+          })
+          assert.equal(release, None)
+          
+          // Instead we can find them by ID
+          const release = await github.rest.repos.getReleaseById({
+            ...context.repo,
+            tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}",
+            release_id: ${{ steps.make-test-draft.outputs.draft_id }}
+          })
+          
+          assert.deepStrictEqual(release.data.draft, true)
+          assert.deepStrictEqual(release.data.body, "rofl lol test\nianal % fubar")
+          assert.deepStrictEqual(release.data.assets[0].name, "TEST.md")
+
     - name: Make test pre-release
       uses: ./
       with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -74,8 +74,6 @@ jobs:
         script: |
           const assert = require('assert').strict;
           
-          const expected = fs.readFileSync("README.md", "utf8")
-          
           const release = await github.request('GET /repos/{owner}/{repo}/releases/{release_id}', {
             ...context.repo,
             release_id: process.env.DRAFT_ID,

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -57,6 +57,42 @@ jobs:
           assert.deepStrictEqual(release.data.body, "rofl lol test\nianal % fubar")
           assert.deepStrictEqual(release.data.assets[0].name, "TEST.md")
 
+    - name: Add files to existing draft
+      uses: ./
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: README.md
+        asset_name: TEST2.md
+        draft_id: ${{ steps.make-test-draft.outputs.draft_id }}
+        tag: ci-test-${{ matrix.os }}-${{ github.run_id }}
+        draft: true
+
+    - name: Check that files can be uploaded to existing draft
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const fs = require('fs')
+          const assert = require('assert').strict;
+          
+          const expected = fs.readFileSync("README.md", "utf8")
+          
+          const release = await github.request('GET /repos/{owner}/{repo}/releases/{release_id}', {
+            ...context.repo,
+            tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}",
+            release_id: process.env.DRAFT_ID,
+          })
+          
+          assert.deepStrictEqual(release.data.prerelease, true)
+          assert.deepStrictEqual(release.data.body, "rofl lol test\nianal % fubar")
+          assert.deepStrictEqual(release.data.assets[0].name, "TEST.md")
+          assert.deepStrictEqual(release.data.assets[1].name, "TEST2.md")
+          const arraybuf = await github.request(release.data.assets[1].browser_download_url)
+          const actual = Buffer.from(arraybuf.data).toString('utf8')
+          console.log(typeof(actual))
+          console.log(typeof(expected))
+          assert.deepStrictEqual(expected, actual)
+
     - name: Make test pre-release
       uses: ./
       with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -49,7 +49,6 @@ jobs:
           // Instead we can find them by ID
           const release = await github.request('GET /repos/{owner}/{repo}/releases/{release_id}', {
             ...context.repo,
-            tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}",
             release_id: process.env.DRAFT_ID,
           })
           
@@ -81,7 +80,6 @@ jobs:
           
           const release = await github.request('GET /repos/{owner}/{repo}/releases/{release_id}', {
             ...context.repo,
-            tag: "ci-test-${{ matrix.os }}-${{ github.run_id }}",
             release_id: process.env.DRAFT_ID,
           })
           

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -69,6 +69,8 @@ jobs:
 
     - name: Check that files can be uploaded to existing draft
       uses: actions/github-script@v7
+      env:
+        DRAFT_ID: ${{ steps.make-test-draft.outputs.draft_id }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -33,7 +33,6 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          const fs = require('fs')
           const assert = require('assert').strict;
 
           // We cannot find drafts by tag
@@ -73,7 +72,6 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          const fs = require('fs')
           const assert = require('assert').strict;
           
           const expected = fs.readFileSync("README.md", "utf8")
@@ -83,7 +81,6 @@ jobs:
             release_id: process.env.DRAFT_ID,
           })
           
-          assert.deepStrictEqual(release.data.body, "rofl lol test\nianal % fubar")
           assert.deepStrictEqual(release.data.assets.map(a => a.name), ["TEST.md", "TEST2.md"])
 
     - name: Make test pre-release

--- a/dist/index.js
+++ b/dist/index.js
@@ -67,15 +67,15 @@ function get_release_by_tag(tag_1, draft_1, prerelease_1, make_latest_1, release
     return __awaiter(this, arguments, void 0, function* (tag, draft, prerelease, make_latest, release_name, body, octokit, overwrite, promote, target_commit, known_draft_id = 0) {
         let release;
         try {
-            core.debug(`Draft ID: ${known_draft_id}`);
+            core.info(`Draft ID: ${known_draft_id}`);
             if (draft && known_draft_id !== 0) {
                 // We are working with a draft release and we already created it
-                core.debug(`Getting release by id ${known_draft_id} because we're working with a draft release.`);
+                core.info(`Getting release by id ${known_draft_id} because we're working with a draft release.`);
                 release = yield octokit.request(releaseByID, Object.assign(Object.assign({}, repo()), { release_id: known_draft_id }));
                 core.debug(`The release has the following ID: ${release.data.id}`);
             }
             else {
-                core.debug(`Getting release by tag ${tag}.`);
+                core.info(`Getting release by tag ${tag}.`);
                 // @ts-ignore
                 release = yield octokit.request(releaseByTag, Object.assign(Object.assign({}, repo()), { tag: tag }));
             }
@@ -84,7 +84,7 @@ function get_release_by_tag(tag_1, draft_1, prerelease_1, make_latest_1, release
             // If this returns 404, we need to create the release first.
             if (error.status !== 404)
                 throw error;
-            core.debug(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
+            core.info(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
             if (target_commit) {
                 try {
                     yield octokit.request(getRef, Object.assign(Object.assign({}, repo()), { ref: `tags/${tag}` }));
@@ -107,18 +107,18 @@ function update_release(promote, release, tag, overwrite, release_name, body, oc
     return __awaiter(this, void 0, void 0, function* () {
         let updateObject;
         if (promote && release.data.prerelease) {
-            core.debug(`The ${tag} is a prerelease, promoting it to a release.`);
+            core.info(`The ${tag} is a prerelease, promoting it to a release.`);
             updateObject = updateObject || {};
             updateObject.prerelease = false;
         }
         if (overwrite) {
             if (release_name && release.data.name !== release_name) {
-                core.debug(`The ${tag} release already exists with a different name ${release.data.name} so we'll overwrite it.`);
+                core.info(`The ${tag} release already exists with a different name ${release.data.name} so we'll overwrite it.`);
                 updateObject = updateObject || {};
                 updateObject.name = release_name;
             }
             if (body && release.data.body !== body) {
-                core.debug(`The ${tag} release already exists with a different body ${release.data.body} so we'll overwrite it.`);
+                core.info(`The ${tag} release already exists with a different body ${release.data.body} so we'll overwrite it.`);
                 updateObject = updateObject || {};
                 updateObject.body = body;
             }
@@ -134,12 +134,12 @@ function upload_to_release(release, file, asset_name, tag, overwrite, octokit, c
     return __awaiter(this, void 0, void 0, function* () {
         const stat = fs.statSync(file);
         if (!stat.isFile()) {
-            core.debug(`Skipping ${file}, since its not a file`);
+            core.warning(`Skipping ${file}, since its not a file`);
             return;
         }
         const file_size = stat.size;
         if (file_size === 0) {
-            core.debug(`Skipping ${file}, since its size is 0`);
+            core.warning(`Skipping ${file}, since its size is 0`);
             return;
         }
         if (check_duplicates) {
@@ -148,7 +148,7 @@ function upload_to_release(release, file, asset_name, tag, overwrite, octokit, c
             const duplicate_asset = assets.find(a => a.name === asset_name);
             if (duplicate_asset !== undefined) {
                 if (overwrite) {
-                    core.debug(`An asset called ${asset_name} already exists in release ${tag} so we'll overwrite it.`);
+                    core.info(`An asset called ${asset_name} already exists in release ${tag} so we'll overwrite it.`);
                     yield octokit.request(deleteAssets, Object.assign(Object.assign({}, repo()), { asset_id: duplicate_asset.id }));
                 }
                 else {
@@ -160,7 +160,7 @@ function upload_to_release(release, file, asset_name, tag, overwrite, octokit, c
                 core.debug(`No pre-existing asset called ${asset_name} found in release ${tag}. All good.`);
             }
         }
-        core.debug(`Uploading ${file} to ${asset_name} in release ${tag}.`);
+        core.info(`Uploading ${file} to ${asset_name} in release ${tag}.`);
         // @ts-ignore
         const uploaded_asset = yield (0, attempt_1.retry)(() => __awaiter(this, void 0, void 0, function* () {
             return octokit.request(uploadAssets, Object.assign(Object.assign({}, repo()), { release_id: release.data.id, url: release.data.upload_url, name: asset_name, data: fs.createReadStream(file), headers: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ async function get_release_by_tag(
   try {
     core.debug(`Draft ID: ${known_draft_id}`)
 
-    if (draft === true && known_draft_id !== 0) {
+    if (draft && known_draft_id !== 0) {
       // We are working with a draft release and we already created it
       core.debug(
         `Getting release by id ${known_draft_id} because we're working with a draft release.`


### PR DESCRIPTION
Added tests to 

- Create a draft - and ensure it's in 'draft' state
- Add a file to the draft - ensure both files are there

Also changed many logs from debug to info - currently the user gets no logs at all by default, which is a shame

This has caused me to realize that 
- draft_id is misleading - release_id is the correct term, since draft is just a state, and release is the name of the object. As further proof, it's called 'release_id', so...
- We can output the release id always, no matter if we created or did not, this could be useful for other things
Those changes serve a different purpose and thus deserve a different commit