### PR TITLE
Solve the race-condition when matrix builds try to create the same release

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -67,23 +67,13 @@ function get_or_create_release(tag_1, draft_1, prerelease_1, make_latest_1, rele
     return __awaiter(this, arguments, void 0, function* (tag, draft, prerelease, make_latest, release_name, body, octokit, overwrite, promote, target_commit, release_id = 0) {
         let release;
         try {
-            if (release_id !== 0) {
-                // Draft releases can only be found by ID, not by tag.
-                core.info(`Getting release by id ${release_id}`);
-                release = yield octokit.request(releaseByID, Object.assign(Object.assign({}, repo()), { release_id: release_id }));
-                core.debug(`The release has the following ID: ${release.data.id}`);
-            }
-            else {
-                core.info(`Getting release by tag ${tag}.`);
-                // @ts-ignore
-                release = yield octokit.request(releaseByTag, Object.assign(Object.assign({}, repo()), { tag: tag }));
-            }
+            release = yield get_release(octokit, tag, release_id);
         }
         catch (error) {
             // If this returns 404, we need to create the release first.
             if (error.status !== 404)
                 throw error;
-            core.info(`Release for tag ${tag} doesn't exist yet so we'll create it now.`);
+            core.info(`Release for tag ${tag} doesn't exist - creating it`);
             if (target_commit) {
                 try {
                     yield octokit.request(getRef, Object.assign(Object.assign({}, repo()), { ref: `tags/${tag}` }));
@@ -103,17 +93,32 @@ function get_or_create_release(tag_1, draft_1, prerelease_1, make_latest_1, rele
                 if (create_release_error.status == 422 &&
                     create_release_error.response.data.errors[0].code == 'already_exists') {
                     core.info(`Tried to create a release for tag ${tag}, but it already exists - probably due to race condition between matrix jobs.`);
-                    // @ts-ignore
-                    release = yield octokit.request(releaseByTag, Object.assign(Object.assign({}, repo()), { tag: tag }));
+                    release = yield get_release(octokit, tag, release_id);
                     // In this case, we do not throw the error, and we don't return since possibly we want to update it
                 }
                 else {
-                    core.setFailed(`Failed to create release release for tag ${tag}: ${error.message}`);
+                    core.setFailed(`Failed to create release for tag ${tag}: ${error.message}`);
                     throw error;
                 }
             }
         }
         return yield update_release(promote, release, tag, overwrite, release_name, body, octokit);
+    });
+}
+/** May throw octokit exceptions */
+function get_release(octokit, tag, release_id) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (release_id !== 0) {
+            // Draft releases can only be found by ID, not by tag.
+            core.info(`Getting release by id ${release_id}`);
+            // @ts-ignore
+            return yield octokit.request(releaseByID, Object.assign(Object.assign({}, repo()), { release_id: release_id }));
+        }
+        else {
+            core.info(`Getting release by tag ${tag}.`);
+            // @ts-ignore
+            return yield octokit.request(releaseByTag, Object.assign(Object.assign({}, repo()), { tag: tag }));
+        }
     });
 }
 function update_release(promote, release, tag, overwrite, release_name, body, octokit) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,30 +42,12 @@ async function get_or_create_release(
 > {
   let release: ReleaseByTagResp | ReleaseByIDResp
   try {
-    if (release_id !== 0) {
-      // Draft releases can only be found by ID, not by tag.
-      core.info(`Getting release by id ${release_id}`)
-      release = await octokit.request(releaseByID, {
-        ...repo(),
-        release_id: release_id
-      })
-
-      core.debug(`The release has the following ID: ${release.data.id}`)
-    } else {
-      core.info(`Getting release by tag ${tag}.`)
-      // @ts-ignore
-      release = await octokit.request(releaseByTag, {
-        ...repo(),
-        tag: tag
-      })
-    }
+    release = await get_release(octokit, tag, release_id)
   } catch (error: any) {
     // If this returns 404, we need to create the release first.
     if (error.status !== 404) throw error
 
-    core.info(
-      `Release for tag ${tag} doesn't exist yet so we'll create it now.`
-    )
+    core.info(`Release for tag ${tag} doesn't exist - creating it`)
     if (target_commit) {
       try {
         await octokit.request(getRef, {
@@ -99,15 +81,11 @@ async function get_or_create_release(
         core.info(
           `Tried to create a release for tag ${tag}, but it already exists - probably due to race condition between matrix jobs.`
         )
-        // @ts-ignore
-        release = await octokit.request(releaseByTag, {
-          ...repo(),
-          tag: tag
-        })
+        release = await get_release(octokit, tag, release_id)
         // In this case, we do not throw the error, and we don't return since possibly we want to update it
       } else {
         core.setFailed(
-          `Failed to create release release for tag ${tag}: ${error.message}`
+          `Failed to create release for tag ${tag}: ${error.message}`
         )
         throw error
       }
@@ -123,6 +101,30 @@ async function get_or_create_release(
     body,
     octokit
   )
+}
+
+/** May throw octokit exceptions */
+async function get_release(
+  octokit: Octokit,
+  tag: string,
+  release_id: number
+): Promise<ReleaseByTagResp | ReleaseByIDResp> {
+  if (release_id !== 0) {
+    // Draft releases can only be found by ID, not by tag.
+    core.info(`Getting release by id ${release_id}`)
+    // @ts-ignore
+    return await octokit.request(releaseByID, {
+      ...repo(),
+      release_id: release_id
+    })
+  } else {
+    core.info(`Getting release by tag ${tag}.`)
+    // @ts-ignore
+    return await octokit.request(releaseByTag, {
+      ...repo(),
+      tag: tag
+    })
+  }
 }
 
 async function update_release(


### PR DESCRIPTION
Resolves #115, resolves #20

When attempting to create a release and we get a "already_exists" response, we retrieve the release again.

I don't love the fact that this means we're 2 try/catches deep (one for 'get release' and another for 'create release') but attempts to encapsulate these into separate functions do not spark joy, I prefer to - as step 1 - actually solve the problem, and then as step 2 to make it look nice.